### PR TITLE
Feature [Expertise]: Update professional summary and split roles

### DIFF
--- a/messages/br.json
+++ b/messages/br.json
@@ -13,7 +13,7 @@
     "role": "Engenheiro de Software.",
     "introduction": "<years></years>+ anos de experiência na construção de sistemas de alta escala para grandes players como Multiplan e PepsiCo.",
     "curiosity": "(e como você pode perceber, também um viciado em café).",
-    "professional_summary": "Especialista no ecossistema JavaScript/TypeScript com foco em otimização de performance e eficiência de infraestrutura. Experiência comprovada liderando o ciclo completo de produtos, de MVPs a ambientes de produção com 100k+ usuários diários e milhões de registros.",
+    "professional_summary": "Escalei um MVP para mais de 30 mil usuários em 30 dias e gerenciei ambientes de produção atendendo mais de 100 mil DAU, impulsionando um aumento de 200% na aquisição de usuários por meio da otimização de infraestrutura e APIs. Combino profunda expertise em System Design com ownership de ponta a ponta do produto, desde decisões de arquitetura até deploys de nível de produção.",
     "personal_space": "Este é o meu espaço. Fique à vontade para trazer ideias e conversas; fico feliz se algo aqui se provar útil para você ou se pudermos construir algo novo juntos.",
     "social_invitation": "Fique à vontade para entrar em contato comigo nas minhas redes sociais!",
     "now": "Momento atual",
@@ -62,27 +62,33 @@
     "multiplan": {
       "title": "Engenheiro de Software",
       "company": "Multiplan Empreendimentos S.A, RJ",
-      "item1": "Desenvolvi e lancei um <strong>MVP completo</strong> para um sistema automatizado de <strong>Reconhecimento de Placas (LPR)</strong> usando <strong>Node.js</strong> e <strong>React</strong>, escalando com sucesso de <strong>30k+ usuários ativos</strong> no primeiro mês para <strong>100k+ usuários diários ativos</strong> com mais de <strong>2M de placas licenciadas</strong> armazenadas.",
-      "item2": "Impulsionei um <strong>aumento de 200% em usuários registrados</strong> (<strong>100k para 300k+</strong>) em 6 meses através da engenharia da orquestração client-side de um <strong>sistema de pagamento multi-provedor</strong>, garantindo uma experiência de checkout sem atritos com provedores como <strong>Sem Parar</strong>, <strong>ConectCar</strong> e <strong>Veloe</strong>.",
-      "item3": "Otimizei a <strong>performance</strong> da aplicação refatorando a <strong>estratégia de cache</strong> com <strong>React Apollo Client</strong>, resultando em uma <strong>redução de 70% nas requisições à API</strong> e uma UX mais rápida.",
-      "item4": "Reduzi o <strong>tempo de processamento</strong> do usuário em <strong>90%</strong> (<strong>10m para <60s</strong>) através da engenharia de um <strong>sistema automatizado de isenção de estacionamento</strong> para <strong>6+ shoppings principais</strong>, eliminando tickets físicos para parceiros como academias e supermercados.",
-      "item5": "Reduzi <strong>erros críticos</strong> em <strong>20%</strong> e cortei custos operacionais aumentando a <strong>cobertura de testes em 30%</strong> e implementando <strong>analytics e observabilidade</strong> avançados com <strong>MixPanel</strong> e <strong>BugSnag</strong>.",
-      "item6": "Aumentei a <strong>retenção de usuários</strong> em <strong>23%</strong> ao migrar as <strong>comunicações dos Carregadores EV</strong> de <strong>WebSockets</strong> para <strong>Polling</strong>, resolvendo problemas críticos de sincronização sob um prazo apertado.",
-      "item7": "Arquitetei <strong>cron job diário</strong> para <strong>migração de categoria de veículos</strong> usando <strong>Node.js</strong>, orquestrando comunicação entre monolito e microserviços via <strong>GraphQL</strong> com <strong>estratégia de processamento em lote</strong> e <strong>Promise.allSettled</strong> para execução tolerante a falhas, e desenvolvi <strong>ferramentas internas de backoffice</strong> para <strong>Testes A/B</strong> e <strong>Feature Flags</strong>."
+      "item1": "Liderei o desenvolvimento frontend de uma plataforma de <strong>estacionamento inteligente</strong> de alto tráfego atendendo <strong>100k+ usuários diários</strong> e armazenando dados de mais de <strong>2M de placas veiculares</strong>, atuando como engenheiro principal da camada voltada ao usuário.",
+      "item2": "Impulsionei um <strong>aumento de 200% em usuários registrados</strong> — de <strong>100k para 300k+</strong> — em 6 meses através da orquestração no client-side de um sistema de <strong>pagamento multi-provedor</strong> com <strong>Sem Parar</strong>, <strong>ConectCar</strong> e <strong>Veloe</strong>, entregando uma experiência de checkout sem atritos.",
+      "item3": "Otimizei a performance da aplicação refatorando a estratégia de cache com <strong>React Apollo Client</strong>, alcançando uma <strong>redução de 70% nas requisições de API</strong> e uma UX mais rápida.",
+      "item4": "Aumentei a retenção de usuários em <strong>23%</strong> migrando as comunicações de <strong>Carregadores EV</strong> de <strong>WebSockets</strong> para <strong>Polling</strong>, resolvendo problemas críticos de sincronização em tempo real.",
+      "item5": "Reduzi erros críticos em <strong>20%</strong> e cortei custos operacionais aumentando a cobertura de testes em <strong>30%</strong> e implementando observabilidade avançada com <strong>MixPanel</strong> e <strong>BugSnag</strong>.",
+      "item6": "Arquitetei um cron job diário para migração de categoria de veículos utilizando <strong>Node.js</strong>, orquestrando a comunicação entre monolito e microsserviços via <strong>GraphQL</strong> com processamento em lote e <strong>Promise.allSettled</strong> para execução escalável e tolerante a falhas."
+    },
+    "multiplan_jr": {
+      "title": "Engenheiro de Software Jr",
+      "company": "Multiplan Empreendimentos S.A, RJ",
+      "item1": "Desenvolvi e lancei um MVP completo para um sistema automatizado de <strong>Reconhecimento de Placas (LPR)</strong> usando <strong>Node.js</strong> e <strong>React</strong>, escalando para <strong>30k+ usuários ativos</strong> no primeiro mês de produção.",
+      "item2": "Reduzi o tempo de processamento do usuário em <strong>90%</strong> — de 10 minutos para menos de 60 segundos — através da engenharia de um sistema automatizado de isenção de estacionamento implementado em <strong>6+ grandes shoppings</strong>, eliminando tickets físicos.",
+      "item3": "Arquitetei ferramentas internas de <strong>backoffice</strong> para <strong>Testes A/B</strong> e <strong>Feature Flags</strong>, empoderando as equipes de Produto e Marketing a conduzir experimentos de forma independente."
     },
     "pepsico": {
-      "title": "Engenheiro de Software (Freelancer)",
-      "company": "Latop / PepsiCo",
-      "item1": "Arquitetei e mantive uma <strong>plataforma crítica de logística de cargas</strong> para a <strong>PepsiCo</strong> usando <strong>Next.js</strong> e <strong>TypeScript</strong>, com foco em <strong>segurança</strong> e <strong>eficiência</strong>.",
-      "item2": "Reduzi <strong>chamadas redundantes à API</strong> em <strong>20%</strong> e <strong>custos de infraestrutura</strong> em <strong>15%</strong> via <strong>cache do React Query</strong> e monitoramento.",
-      "item3": "Desenvolvi uma <strong>sincronização periódica de 10 minutos</strong> para <strong>monitoramento de caminhões</strong>, garantindo <strong>precisão no dashboard</strong> e otimizando <strong>overhead de rede</strong>."
+      "title": "Engenheiro de Software",
+      "company": "Latop (PepsiCo)",
+      "item1": "Projetei e entreguei uma <strong>plataforma de logística de frete</strong> para a <strong>PepsiCo</strong>, habilitando visibilidade em tempo real e sincronização de dados entre múltiplos centros de distribuição nacionais.",
+      "item2": "Eliminei tráfego de rede redundante e melhorei a alocação de recursos para funcionalidades logísticas refatorando a camada de sincronização de dados com <strong>React Query</strong>, melhorando a confiabilidade da plataforma.",
+      "item3": "Desenvolvi um <strong>mecanismo de sincronização periódica de 10 minutos</strong> para monitoramento de frota, garantindo a precisão dos dashboards em tempo real enquanto otimizava o overhead de rede."
     },
     "neurogram": {
-      "title": "Engenheiro de Software (Freelancer)",
+      "title": "Engenheiro de Software",
       "company": "Neurogram",
-      "item1": "Desenvolvi <strong>landing pages dinâmicas de alta performance</strong> em <strong>React</strong>, focadas em <strong>UX orientada a produto</strong> e <strong>otimização de conversão</strong>.",
-      "item2": "Automatizei <strong>ciclos de entrega</strong> com <strong>pipelines CI/CD</strong> (<strong>GitHub Actions</strong>, <strong>Firebase</strong>), aumentando a <strong>frequência de deploy</strong> e <strong>escalabilidade</strong>.",
-      "item3": "Integrei <strong>algoritmos de diagnóstico médico</strong> em uma <strong>plataforma de exames EEG</strong>, possibilitando <strong>processamento complexo de dados neurológicos</strong> para <strong>suporte clínico</strong>."
+      "item1": "Integrei algoritmos de diagnóstico médico em uma <strong>plataforma de exames EEG</strong>, possibilitando processamento complexo de dados neurológicos para suporte a decisões clínicas.",
+      "item2": "Desenvolvi landing pages dinâmicas de alta performance usando <strong>React</strong>, otimizando para uma experiência do usuário voltada ao produto e conversão.",
+      "item3": "Automatizei ciclos de deploy implementando pipelines de CI/CD com <strong>GitHub Actions</strong> e <strong>Firebase</strong>, aumentando a frequência de entregas e garantindo escalabilidade de infraestrutura."
     }
   },
   "BackButton": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,7 +13,7 @@
     "role": "Software Engineer.",
     "introduction": "<years></years>+ years of professional experience building high-scale systems for major players like Multiplan and PepsiCo.",
     "curiosity": "(and as you probably have noticed, also a coffee lover).",
-    "professional_summary": "Expert in the JavaScript/TypeScript ecosystem with a strong focus on infrastructure optimization and performance. Proven ability to lead end-to-end product development, from initial MVPs to production environments serving 100k+ daily active users and millions of records.",
+    "professional_summary": "Scaled an MVP to 30k+ users in 30 days and managed production environments serving 100k+ DAU, while driving a 200% increase in user acquisition through infrastructure and API optimization. Combines deep expertise in System Design with end-to-end product ownership, from architecture decisions to production-grade deployment.",
     "personal_space": "This is my own corner of the web. You're more than welcome to jump in with ideas or start a conversation; any exchange that proves useful is always welcome.",
     "social_invitation": "Feel free to reach out to me on my social media!",
     "now": "My current moment",
@@ -62,27 +62,33 @@
     "multiplan": {
       "title": "Software Engineer",
       "company": "Multiplan Empreendimentos S.A, RJ",
-      "item1": "Developed and launched an <strong>end-to-end MVP</strong> for an automated <strong>License Plate Recognition (LPR) system</strong> using <strong>Node.js</strong> and <strong>React</strong>, successfully scaling to <strong>30k+ active users</strong> within the first month and growing to <strong>100k+ daily active users</strong> with over <strong>2M licensed plates</strong> stored.",
-      "item2": "Drove a <strong>200% increase in registered users</strong> (<strong>100k to 300k+</strong>) in 6 months by engineering the client-side orchestration of a <strong>multi-provider payment system</strong>, ensuring a frictionless checkout experience with providers like <strong>Sem Parar</strong>, <strong>ConectCar</strong> and <strong>Veloe</strong>.",
-      "item3": "Optimized application <strong>performance</strong> by refactoring the <strong>caching strategy</strong> with <strong>React Apollo Client</strong>, resulting in a <strong>70% reduction in API requests</strong> and a faster UX.",
-      "item4": "Reduced user <strong>processing time by 90%</strong> (<strong>10m to <60s</strong>) by engineering an automated <strong>parking exemption system</strong> for <strong>6+ major malls</strong>, eliminating physical tickets for partners like gyms and supermarkets.",
-      "item5": "Decreased <strong>critical errors</strong> by <strong>20%</strong> and cut operational costs by increasing <strong>test coverage by 30%</strong> and implementing advanced <strong>analytics and observability</strong> with <strong>MixPanel</strong> and <strong>BugSnag</strong>.",
-      "item6": "Boosted <strong>user retention</strong> by <strong>23%</strong> by migrating <strong>EV Charger communications</strong> from <strong>WebSockets</strong> to <strong>Polling</strong>, resolving critical sync issues under a tight deadline.",
-      "item7": "Architected daily <strong>cron job</strong> for <strong>vehicle tier migration</strong> using <strong>Node.js</strong>, orchestrating monolith and microservice communication via <strong>GraphQL</strong> with a <strong>batch processing strategy</strong> and <strong>Promise.allSettled</strong> for fault-tolerant execution, and developed internal <strong>backoffice tools</strong> for <strong>A/B testing</strong> and <strong>Feature Flags</strong>."
+      "item1": "Led frontend development for a high-traffic <strong>smart parking platform</strong> serving <strong>100k+ daily active users</strong> and storing data from over <strong>2M licensed plates</strong>, acting as the primary engineer for the product's core user-facing layer.",
+      "item2": "Drove a <strong>200% increase in registered users</strong> — from <strong>100k to 300k+</strong> — in 6 months by engineering the client-side orchestration of a <strong>multi-provider payment system</strong> with <strong>Sem Parar</strong>, <strong>ConectCar</strong>, and <strong>Veloe</strong>, delivering a frictionless checkout experience.",
+      "item3": "Optimized application performance by refactoring the caching strategy with <strong>React Apollo Client</strong>, achieving a <strong>70% reduction in API requests</strong> and a measurably faster UX.",
+      "item4": "Boosted user retention by <strong>23%</strong> by migrating <strong>EV Charger communications</strong> from <strong>WebSockets</strong> to <strong>Polling</strong>, resolving critical real-time sync issues under a tight production deadline.",
+      "item5": "Decreased critical errors by <strong>20%</strong> and reduced operational costs by increasing test coverage by <strong>30%</strong> and implementing advanced observability with <strong>MixPanel</strong> and <strong>BugSnag</strong>.",
+      "item6": "Architected a daily cron job for vehicle tier migration using <strong>Node.js</strong>, orchestrating communication between monolith and microservices via <strong>GraphQL</strong> with batch processing and <strong>Promise.allSettled</strong> for fault-tolerant, scalable execution."
+    },
+    "multiplan_jr": {
+      "title": "Software Engineer Jr",
+      "company": "Multiplan Empreendimentos S.A, RJ",
+      "item1": "Developed and launched an end-to-end MVP for an automated <strong>License Plate Recognition (LPR) system</strong> using <strong>Node.js</strong> and <strong>React</strong>, scaling to <strong>30k+ active users</strong> within the first month of production.",
+      "item2": "Reduced user processing time by <strong>90%</strong> — from 10 minutes to under 60 seconds — by engineering an automated parking exemption system deployed across <strong>6+ major malls</strong>, eliminating physical tickets for partner businesses such as gyms and supermarkets.",
+      "item3": "Architected internal <strong>backoffice tooling</strong> for <strong>A/B testing</strong> and <strong>Feature Flags</strong>, empowering Product and Marketing teams to run experiments independently and reducing engineering bottlenecks in the product release cycle."
     },
     "pepsico": {
-      "title": "Software Engineer (Contractor)",
-      "company": "Latop / PepsiCo",
-      "item1": "Architected and maintained a <strong>critical freight logistics platform</strong> for <strong>PepsiCo</strong> using <strong>Next.js</strong> and <strong>TypeScript</strong>, focusing on <strong>security</strong> and <strong>efficiency</strong>.",
-      "item2": "Reduced <strong>redundant API calls</strong> by <strong>20%</strong> and <strong>infrastructure costs</strong> by <strong>15%</strong> via <strong>React Query caching</strong> and monitoring.",
-      "item3": "Engineered a <strong>10-minute periodic sync</strong> for <strong>truck monitoring</strong>, ensuring <strong>dashboard accuracy</strong> and optimized <strong>network overhead</strong>."
+      "title": "Software Engineer",
+      "company": "Latop (PepsiCo)",
+      "item1": "Designed and delivered a <strong>freight logistics platform</strong> for <strong>PepsiCo</strong>, enabling real-time visibility and data synchronization across multiple national distribution centers.",
+      "item2": "Eliminated redundant network traffic and improved resource allocation for critical logistics features by refactoring the data synchronization layer with <strong>React Query</strong>, directly improving platform reliability.",
+      "item3": "Engineered a <strong>10-minute periodic synchronization mechanism</strong> for regional fleet monitoring, ensuring real-time dashboard accuracy across distribution hubs while optimizing network overhead."
     },
     "neurogram": {
-      "title": "Software Engineer (Contractor)",
+      "title": "Software Engineer",
       "company": "Neurogram",
-      "item1": "Developed <strong>high-performance dynamic landing pages</strong> in <strong>React</strong>, focused on <strong>product-driven UX</strong> and <strong>conversion optimization</strong>.",
-      "item2": "Automated <strong>delivery cycles</strong> with <strong>CI/CD pipelines</strong> (<strong>GitHub Actions</strong>, <strong>Firebase</strong>), increasing <strong>deployment frequency</strong> and <strong>scalability</strong>.",
-      "item3": "Integrated <strong>medical diagnostic algorithms</strong> into an <strong>EEG exam platform</strong>, enabling <strong>complex neurological data processing</strong> for <strong>clinical support</strong>."
+      "item1": "Integrated medical diagnostic algorithms into an <strong>EEG exam platform</strong>, enabling complex neurological data processing to support clinical decision-making for healthcare professionals.",
+      "item2": "Developed high-performance dynamic landing pages using <strong>React</strong>, optimizing for product-driven user experience and conversion.",
+      "item3": "Automated deployment cycles by implementing CI/CD pipelines with <strong>GitHub Actions</strong> and <strong>Firebase</strong>, increasing deployment frequency and ensuring infrastructure scalability."
     }
   },
   "BackButton": {

--- a/src/components/Expertise/index.test.tsx
+++ b/src/components/Expertise/index.test.tsx
@@ -11,21 +11,26 @@ vi.mock("next-intl", () => ({
 }));
 
 describe("Expertise", () => {
-  it("should return 3 milestones with correct structure", () => {
+  it("should return 4 milestones with correct structure", () => {
     const milestones = Expertise();
     
-    expect(milestones).toHaveLength(3);
+    expect(milestones).toHaveLength(4);
     expect(milestones[0]).toMatchObject({
       id: 1,
-      startDate: "2022-02-01",
+      startDate: "2023-11-01",
     });
     expect(milestones[1]).toMatchObject({
       id: 2,
-      startDate: "2024-07-01",
-      endDate: "2025-09-30",
+      startDate: "2022-02-01",
+      endDate: "2023-11-01",
     });
     expect(milestones[2]).toMatchObject({
       id: 3,
+      startDate: "2024-07-01",
+      endDate: "2025-09-30",
+    });
+    expect(milestones[3]).toMatchObject({
+      id: 4,
       startDate: "2024-04-01",
       endDate: "2024-09-30",
     });

--- a/src/components/Expertise/index.tsx
+++ b/src/components/Expertise/index.tsx
@@ -15,7 +15,7 @@ export const Expertise = (): MilestoneType[] => {
       id: 1,
       title: t("multiplan.title"),
       company: t("multiplan.company"),
-      startDate: "2022-02-01",
+      startDate: "2023-11-01",
       endDate: new Date().toISOString(),
       description: (
         <ul className={cn(listClass)} >
@@ -25,12 +25,25 @@ export const Expertise = (): MilestoneType[] => {
           <li>{t.rich("multiplan.item4", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
           <li>{t.rich("multiplan.item5", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
           <li>{t.rich("multiplan.item6", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
-          <li>{t.rich("multiplan.item7", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
         </ul>
       )
     },
     {
       id: 2,
+      title: t("multiplan_jr.title"),
+      company: t("multiplan_jr.company"),
+      startDate: "2022-02-01",
+      endDate: "2023-11-01",
+      description: (
+        <ul className={cn(listClass)} >
+          <li>{t.rich("multiplan_jr.item1", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
+          <li>{t.rich("multiplan_jr.item2", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
+          <li>{t.rich("multiplan_jr.item3", { strong: (chunks) => <strong className={highlightClass}>{chunks}</strong> })}</li>
+        </ul>
+      )
+    },
+    {
+      id: 3,
       title: t("pepsico.title"),
       company: t("pepsico.company"),
       startDate: "2024-07-01",
@@ -44,7 +57,7 @@ export const Expertise = (): MilestoneType[] => {
       )
     },
     {
-      id: 3,
+      id: 4,
       title: t("neurogram.title"),
       company: t("neurogram.company"),
       startDate: "2024-04-01",


### PR DESCRIPTION
## Changelog
- feat(expertise): update professional summary and split roles

## Notes to reviewer
- **messages**: Updated professional_summary and experience items for multiplan, pepsico, and neurogram in both en.json and br.json.
- **expertise**: Split Multiplan experience into multiplan (Software Engineer) and multiplan_jr (Software Engineer Jr) to better reflect career timeline.
- **tests**: Updated Expertise tests to account for the additional milestone (4 total).

## How to test
1. Run pnpm dev.
2. Navigate to the About/Expertise section.
3. Verify the updated descriptions and the new role split.
4. Run pnpm test to ensure tests pass.