### PR TITLE
Fix [Layout]: Change overflow to auto for better scrolling

### DIFF
--- a/src/components/Layout/index.test.tsx
+++ b/src/components/Layout/index.test.tsx
@@ -11,7 +11,7 @@ describe("Layout component", () => {
     );
     const mainElement = container.firstChild;
     expect(mainElement).toHaveClass(
-      "text-primary dark:text-primary-foreground screen-layout relative h-dvh overflow-y-scroll",
+      "text-primary dark:text-primary-foreground screen-layout relative h-dvh overflow-auto",
     );
   });
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -8,7 +8,7 @@ export const Layout = ({ children }: { children: ReactNode }) => {
       display="flex"
       direction="col"
       align="center"
-      className="text-primary dark:text-primary-foreground screen-layout relative h-dvh overflow-y-scroll"
+      className="text-primary dark:text-primary-foreground screen-layout relative h-dvh overflow-auto"
     >
       {children}
     </Box>


### PR DESCRIPTION
## Changelog
- fix(layout): change overflow to auto for better scrolling

## Notes to reviewer
- **components**: Changed overflow-y-scroll to overflow-auto in the Layout component. This prevents unnecessary scrollbars on pages that don't need them.
- **tests**: Updated Layout tests to match the new class.

## How to test
1. Check pages with little content; they should not have a disabled vertical scrollbar.
2. Check long pages; they should still scroll correctly.