### PR TITLE
Fix [GitHub]: Correct lint command in CI workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run lint:ci
-        run: pnpm lint:ci
+      - name: Run lint
+        run: pnpm lint
 
       - name: Run Tests
         run: pnpm test


### PR DESCRIPTION
## Workflow Fix

Changed pnpm lint:ci to pnpm lint to fix CI failure as the script was missing in package.json.